### PR TITLE
added lines to handle emacs 25 compiles

### DIFF
--- a/ilisp-mak.el
+++ b/ilisp-mak.el
@@ -46,6 +46,8 @@
            (byte-compile-file "illuc19.el"))
           ((eq +ilisp-emacs-version-id+ 'xemacs)
            (byte-compile-file "ilxemacs.el"))
+          ((eq +ilisp-emacs-version-id+ 'fsf-25)
+           (byte-compile-file "ilfsf25.el"))
           ((eq +ilisp-emacs-version-id+ 'fsf-24)
            (byte-compile-file "ilfsf24.el"))
           ((eq +ilisp-emacs-version-id+ 'fsf-23)


### PR DESCRIPTION
I was trying to compile this for emacs 25.3 and got the error:

$ make compile
/opt/emacs/25.3/bin/emacs -batch -l ilisp-mak.el
ILISP Compilation: starting.
Loading /usr/src/local/emacs/25.3/ilisp-from-github/ilisp-master/ilcompat.el (source)...
Loading /usr/src/local/emacs/25.3/ilisp-from-github/ilisp-master/ilfsf25.el (source)...
;;; Emacs Version fsf-25
ILISP Compilation: unrecognized Emacs version fsf-25
make: *** [compile] Error 255

I saw there was a ilfsf25.el file but not a correspanding stanza for it in ilisp-mak.el.

So, just added those lines to get further in the compile.