### PR TITLE
Cl lib change

### DIFF
--- a/completer.el
+++ b/completer.el
@@ -79,7 +79,7 @@
 ;;;
 
 
-(require 'cl)
+(require 'cl-lib)
 
 ;; Necessary when loading completer.el, but have not yet loaded ilisp
 (require 'ilcompat)

--- a/extra/cltl2.el
+++ b/extra/cltl2.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'browse-url)			;you need the Emacs 20 version
 (require 'thingatpt)
 

--- a/extra/hyperspec.el
+++ b/extra/hyperspec.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(require 'cl-lib)
 (require 'browse-url)                   ;you need the Emacs 20 version
 (require 'thingatpt)
 

--- a/ilcompat.el
+++ b/ilcompat.el
@@ -8,7 +8,7 @@
 ;;; Please refer to the file ACKNOWLEGDEMENTS for an (incomplete) list
 ;;; of present and past contributors.
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;; Global definitions/declarations
 

--- a/ild.el
+++ b/ild.el
@@ -32,7 +32,7 @@
 ;;; 19990615 Marco Antoniotti
 
 ;;; (require 'ilisp)
-(require 'cl)
+(require 'cl-lib)
 (require 'ilisp-key)
 
 (deflocal ild-abort-string nil)

--- a/ilisp-ccl.el
+++ b/ilisp-ccl.el
@@ -25,7 +25,7 @@
 ;;; Dialect definition for Corman Common Lisp by Roger Corman
 ;;; Since 1.4 (fixed with 1.41) there is a debugger with corman.
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;; cormanlisp --
 ;;;

--- a/ilisp-chs.el
+++ b/ilisp-chs.el
@@ -9,7 +9,7 @@
 ;;; Please refer to the file ACKNOWLEGDEMENTS for an (incomplete) list
 ;;; of present and past contributors.
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;; clisp-hs-check-prompt doesn't after the first break because the
 ;;; number of ">" characters doesn't increase.

--- a/ilisp-cl-easy-menu.el
+++ b/ilisp-cl-easy-menu.el
@@ -69,7 +69,7 @@
 ;> 	    (member +ilisp-emacs-version-id+ '(xemacs lucid-19 lucid-19-new)))
 ;> 	   (not (featurep 'ilisp-easy-menu)))
 
-(require 'cl)
+(require 'cl-lib)
 (require 'easymenu)
 
 (eval-when (load compile eval)

--- a/ilisp-dia.el
+++ b/ilisp-dia.el
@@ -80,7 +80,7 @@
 ;;; ILISP dialect definition code.
 ;;;
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;;%Dialects
 (defun lisp-add-dialect (dialect)

--- a/ilisp-hi.el
+++ b/ilisp-hi.el
@@ -9,7 +9,7 @@
 ;;; Please refer to the file ACKNOWLEGDEMENTS for an (incomplete) list
 ;;; of present and past contributors.
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;;%Eval/compile
 (defun lisp-send-region (start end switch message status format

--- a/ilisp-imenu.el
+++ b/ilisp-imenu.el
@@ -9,7 +9,7 @@
 ;;; of present and past contributors.
 
 
-(require 'cl)
+(require 'cl-lib)
 (require 'imenu)
 
 ;;; modified for a better display of function+arglist!

--- a/ilisp-mod.el
+++ b/ilisp-mod.el
@@ -11,7 +11,7 @@
 
 ;;;%ilisp-mode
 
-(require 'cl)
+(require 'cl-lib)
 
 (defun ilisp-byte-code-to-list (function)
   "Returns a list suitable for passing to make-byte-code from FUNCTION."

--- a/ilisp-prc.el
+++ b/ilisp-prc.el
@@ -9,7 +9,7 @@
 ;;; Please refer to the file ACKNOWLEGDEMENTS for an (incomplete) list
 ;;; of present and past contributors.
 
-(require 'cl)
+(require 'cl-lib)
 
 (defun ilisp-process ()
   "Return the current ILISP process."

--- a/ilisp-sbcl.el
+++ b/ilisp-sbcl.el
@@ -11,7 +11,7 @@
 
 ;;;%%%Steel Bank Common Lisp
 
-(require 'cl)
+(require 'cl-lib)
 
 (defvar ilisp-sbcl-init-file
   ;; Note: The init file source extension (".lisp") needs to be

--- a/ilisp-sch.el
+++ b/ilisp-sch.el
@@ -9,7 +9,7 @@
 ;;; Please refer to the file ACKNOWLEGDEMENTS for an (incomplete) list
 ;;; of present and past contributors.
 
-(require 'cl)				; Sorry. I couldn't resist
+(require 'cl-lib)				; Sorry. I couldn't resist
 					; 19990818 Marco Antoniotti
 
 ;;; Scheme

--- a/ilisp-src.el
+++ b/ilisp-src.el
@@ -8,7 +8,7 @@
 ;;; Please refer to the file ACKNOWLEGDEMENTS for an (incomplete) list
 ;;; of present and past contributors.
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;; See ilisp.el for more information.
 

--- a/ilisp-xfr.el
+++ b/ilisp-xfr.el
@@ -9,7 +9,7 @@
 ;;; Please refer to the file ACKNOWLEGDEMENTS for an (incomplete) list
 ;;; of present and past contributors.
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;; return-ilisp --
 ;;; It's too bad that this function copies so much code from comint-send-input.

--- a/ilisp.el
+++ b/ilisp.el
@@ -64,7 +64,7 @@
 ;;; interactively, then the lisp or ilisp comes at the end of the
 ;;; function name, otherwise at the start.
 
-(require 'cl)
+(require 'cl-lib)
 
 ;;;%Requirements
 (if (string-match "\\`18" emacs-version)


### PR DESCRIPTION
cleaning up some warnings I'm seeing when compiling ilisp for emacs 25.3.

"Warning: cl package required at runtime"

A quick web search suggest that cl-lib should now be used (at least since 24)

https://stackoverflow.com/questions/5019724/in-emacs-what-does-this-error-mean-warning-cl-package-required-at-runtime#5020049

This PR branch contains all the files with that warning.